### PR TITLE
feat: adds support for a couple of JetBrains' editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,10 @@ Branch names are sanitized for folder names (slashes become dashes):
 | Cursor | `cursor` | `cursor` |
 | VS Code | `code` | `vscode` |
 | Claude Code | `claude` | `claude` |
+| GoLand | `goland` | `goland` |
+| RustRover | `rust-rover` | `rust-rover` |
+| Webstorm | `webstorm` | `webstorm` |
+| PyCharm | `pycharm` | `pycharm` |
 
 The editor opens immediately after worktree creation (doesn't wait for setup to complete).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bonsai",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Git worktree workflow CLI - carefully cultivate your branches",
   "type": "module",
   "bin": {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -3,6 +3,7 @@ import { join, basename, dirname } from "path";
 import { mkdir } from "fs/promises";
 import { parse, stringify } from "smol-toml";
 import { $ } from "bun";
+import type { EditorName } from "./editor.ts";
 
 /**
  * Bonsai configuration structure
@@ -13,7 +14,7 @@ export interface BonsaiConfig {
     worktree_base: string;
   };
   editor: {
-    name: "cursor" | "vscode" | "claude";
+    name: EditorName;
   };
   setup: {
     /** Array of shell commands to run after creating worktree */

--- a/src/lib/editor.ts
+++ b/src/lib/editor.ts
@@ -3,7 +3,14 @@ import { spawn, which } from "bun";
 /**
  * Supported editors
  */
-export type EditorName = "cursor" | "vscode" | "claude";
+export type EditorName =
+  "cursor" |
+  "vscode" |
+  "claude" |
+  "goland" |
+  "pycharm" |
+  "webstorm" |
+  "rustrover";
 
 /**
  * Editor CLI commands
@@ -13,6 +20,10 @@ const EDITOR_COMMANDS: Record<EditorName, string> = {
   cursor: "cursor",
   vscode: "code",
   claude: "claude",
+  goland: "goland",
+  pycharm: "pycharm",
+  webstorm: "webstorm",
+  rustrover: "rustrover",
 } as const;
 
 /**
@@ -46,6 +57,10 @@ export function getEditorDisplayName(editor: EditorName): string {
     cursor: "Cursor",
     vscode: "VS Code",
     claude: "Claude Code",
+    goland: "GoLand",
+    pycharm: "PyCharm",
+    webstorm: "WebStorm",
+    rustrover: "RustRover",
   };
   return names[editor];
 }


### PR DESCRIPTION
This PR adds support for the editors below:
- GoLand
- RustRover
- WebStorm
- PyCharm